### PR TITLE
Add NDS decompressor tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # nds-decompressor
-A Python version of a decompressor for Navigation Data Standard (NDS) files
+
+A Python 3.9 implementation for decompressing Navigation Data Standard (NDS)
+ZipVFS databases.
+
+Given an NDS file it verifies the `ZV` magic header, parses the ZipVFS page map
+and uses the built in `zlib` module to decompress all pages into a regular
+SQLite database file.
+
+## Usage
+
+```bash
+python nds_decompressor.py example.nds output.sqlite
+```
+
+If the output file is omitted it will create `example.nds.sqlite` in the same
+directory.
+
+## Running Tests
+
+Use Python's unittest discovery to run the automated tests:
+
+```bash
+python -m unittest -v
+```

--- a/nds_decompressor.py
+++ b/nds_decompressor.py
@@ -1,0 +1,110 @@
+import zlib
+from dataclasses import dataclass
+from typing import List
+
+SLOT_HEADER_SIZE = 6
+PAGE_MAP_START = 200  # 0xC8
+
+
+def _read_uint_be(b: bytes, offset: int, length: int) -> int:
+    """Read an unsigned big endian integer from a bytes object."""
+    return int.from_bytes(b[offset:offset + length], byteorder='big')
+
+
+@dataclass
+class ZipVfsPageInfo:
+    offset: int
+    size: int
+    unused_bytes: int
+
+    @classmethod
+    def from_bytes(cls, b: bytes, offset: int) -> 'ZipVfsPageInfo':
+        if len(b) - offset < 8:
+            raise ValueError("Buffer too small for ZipVfsPageInfo")
+        page_offset = _read_uint_be(b, offset, 5)
+        tmp = _read_uint_be(b, offset + 5, 3)
+        page_size = tmp >> 7
+        unused = tmp & 0x7F
+        return cls(page_offset, page_size, unused)
+
+
+@dataclass
+class ZipVfsHeader:
+    data_start: int
+    data_end: int
+    db_size: int
+    page_size: int
+    version: int
+    page_map: List[ZipVfsPageInfo]
+
+    @classmethod
+    def from_bytes(cls, b: bytes) -> 'ZipVfsHeader':
+        if len(b) < PAGE_MAP_START:
+            raise ValueError("Header must be at least 200 bytes")
+        data_start = _read_uint_be(b, 108, 8)
+        data_end = _read_uint_be(b, 116, 8)
+        db_size = _read_uint_be(b, 140, 8)
+        page_size = _read_uint_be(b, 172, 4)
+        version = _read_uint_be(b, 176, 4)
+        return cls(data_start, data_end, db_size, page_size, version, [])
+
+    def init_page_map(self, b: bytes) -> None:
+        self.page_map = []
+        for i in range(0, len(b), 8):
+            if i + 8 > len(b):
+                break
+            pi = ZipVfsPageInfo.from_bytes(b, i)
+            if pi.offset == 0:
+                break
+            self.page_map.append(pi)
+
+
+def decompress_nds(src_path: str, dest_path: str = None) -> str:
+    """Decompress an NDS/ZipVFS file to an SQLite database file."""
+    if dest_path is None:
+        dest_path = src_path + '.sqlite'
+
+    with open(src_path, 'rb') as f:
+        header = f.read(PAGE_MAP_START)
+        if len(header) < PAGE_MAP_START:
+            raise ValueError('File too small to be a valid NDS file')
+        if not header.startswith(b'ZV'):
+            raise ValueError('File does not appear to be a ZipVFS/NDS file')
+
+        zh = ZipVfsHeader.from_bytes(header)
+        page_map_len = zh.data_start - PAGE_MAP_START
+        page_map_bytes = f.read(page_map_len)
+        if len(page_map_bytes) != page_map_len:
+            raise ValueError('Truncated page map')
+        zh.init_page_map(page_map_bytes)
+
+        with open(dest_path, 'wb') as out:
+            for page in zh.page_map:
+                f.seek(page.offset)
+                data = f.read(page.size)
+                if len(data) < page.size:
+                    raise ValueError(f'Truncated page at offset {page.offset}')
+                if len(data) < SLOT_HEADER_SIZE:
+                    continue
+                if not (len(data) >= SLOT_HEADER_SIZE + 2 and data[SLOT_HEADER_SIZE] == 0x78 and data[SLOT_HEADER_SIZE + 1] in (0x01, 0x9C, 0xDA)):
+                    # not a zlib stream
+                    continue
+                try:
+                    decompressed = zlib.decompress(data[SLOT_HEADER_SIZE:])
+                except zlib.error:
+                    continue
+                out.write(decompressed)
+
+    return dest_path
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Decompress NDS ZipVFS database')
+    parser.add_argument('source', help='Input NDS file')
+    parser.add_argument('destination', nargs='?', help='Output SQLite file')
+    args = parser.parse_args()
+
+    output = decompress_nds(args.source, args.destination)
+    print(f'Decompressed file written to {output}')

--- a/tests/test_nds_decompressor.py
+++ b/tests/test_nds_decompressor.py
@@ -1,0 +1,73 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+import zlib
+
+from nds_decompressor import (
+    decompress_nds,
+    SLOT_HEADER_SIZE,
+    PAGE_MAP_START,
+)
+
+class TestNds(unittest.TestCase):
+    def _create_sqlite_db(self, path: str) -> bytes:
+        conn = sqlite3.connect(path)
+        conn.execute("PRAGMA page_size=4096")
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)")
+        conn.execute("INSERT INTO t (data) VALUES ('hello')")
+        conn.commit()
+        conn.close()
+        with open(path, 'rb') as f:
+            return f.read()
+
+    def _build_nds_file(self, db_bytes: bytes, nds_path: str) -> None:
+        slot_payload = zlib.compress(db_bytes)
+        slot = b"\x00" * SLOT_HEADER_SIZE + slot_payload
+        data_start = PAGE_MAP_START + 8
+        data_end = data_start + len(slot)
+
+        header = bytearray(200)
+        header[:2] = b"ZV"
+        header[108:116] = data_start.to_bytes(8, 'big')
+        header[116:124] = data_end.to_bytes(8, 'big')
+        header[140:148] = len(db_bytes).to_bytes(8, 'big')
+        header[172:176] = (4096).to_bytes(4, 'big')
+        header[176:180] = (1).to_bytes(4, 'big')
+
+        page_map = bytearray()
+        page_map += data_start.to_bytes(5, 'big')
+        tmp = (len(slot) << 7)
+        page_map += tmp.to_bytes(3, 'big')
+
+        with open(nds_path, 'wb') as f:
+            f.write(header)
+            f.write(page_map)
+            f.write(slot)
+
+    def test_decompress_valid_nds(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, 'db.sqlite')
+            nds_path = os.path.join(tmpdir, 'db.nds')
+            db_bytes = self._create_sqlite_db(db_path)
+            self._build_nds_file(db_bytes, nds_path)
+
+            output = decompress_nds(nds_path)
+            self.assertTrue(os.path.exists(output))
+
+            conn = sqlite3.connect(output)
+            row = conn.execute('SELECT data FROM t WHERE id=1').fetchone()
+            conn.close()
+            self.assertEqual(row[0], 'hello')
+
+    def test_invalid_header(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nds_path = os.path.join(tmpdir, 'bad.nds')
+            with open(nds_path, 'wb') as f:
+                f.write(b'not an nds file')
+
+            with self.assertRaises(ValueError):
+                decompress_nds(nds_path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unittest suite generating a fake NDS file with an SQLite payload
- remove unused import from `nds_decompressor.py`
- document test execution in README

## Testing
- `python3 -m py_compile nds_decompressor.py tests/test_nds_decompressor.py`
- `python3 -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_68420b5feb64832da772b6f4b14af7ee